### PR TITLE
Add support for fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Find-the-command is a bunch of simple command-not-found hooks, intended for using with pacman, it is primarily targeting Arch-based distros. It uses pacman functionality for searching files, introduced in 5.0 release, so there are no useless pkgfile dependencies.
 
-For now, there are only bash and zsh hooks. I am not familiar with fish, so there's no fish support, but I'll apreciate if someone contributes to its support.
-
 ## How does it work?
 
 Interactive shells have an ability to run a specified function when entered command is not found. So these hooks contain a simple function, which is run when shell fails to find any local executables in PATH, aliases and functions matching entered command. There are both interactive hooks, which are providing installation prompt and some other useful functionality (like showing info about package), and 'non-interactive', which are only displaying a package (or list of packages) that provides needed command.
@@ -24,15 +22,15 @@ To enable it, you need to source needed file from `/usr/share/doc/find-the-comma
 
 You can also append some options when sourcing file to customize your experience.
 
-| Option              | Description                                                                     | Bash | Zsh |
-| ------------------- | ------------------------------------------------------------------------------- |:----:|:---:|
-| `noprompt`          | Disable installation prompt.                                                    | ✓    | ✓   |
-| `quiet`             | Decrese verbosity.                                                              | ✓    | ✓   |
-| `su`                | Always use `su` instead of `sudo`.                                              | ✓    | ✓   |
-| `install`           | Automatically install the package without prompting for action.                 | ✗    | ✓   |
-| `info`              | Automatically print package info without prompting for action.                  | ✗    | ✓   |
-| `list_files`        | Automatically print a list of package files without prompting for action.       | ✗    | ✓   |
-| `list_files_paged`  | Automatically print a paged list of package files without prompting for action. | ✗    | ✓   |
+| Option              | Description                                                                     | Bash | Zsh | Fish |
+| ------------------- | ------------------------------------------------------------------------------- |:----:|:---:|:----:|
+| `noprompt`          | Disable installation prompt.                                                    | ✓    | ✓   | ✓    |
+| `quiet`             | Decrese verbosity.                                                              | ✓    | ✓   | ✓    |
+| `su`                | Always use `su` instead of `sudo`.                                              | ✓    | ✓   | ✓    |
+| `install`           | Automatically install the package without prompting for action.                 | ✗    | ✓   | ✓    |
+| `info`              | Automatically print package info without prompting for action.                  | ✗    | ✓   | ✓    |
+| `list_files`        | Automatically print a list of package files without prompting for action.       | ✗    | ✓   | ✓    |
+| `list_files_paged`  | Automatically print a paged list of package files without prompting for action. | ✗    | ✓   | ✓    |
 
 For example:
 

--- a/usr/share/doc/find-the-command/ftc.fish
+++ b/usr/share/doc/find-the-command/ftc.fish
@@ -1,0 +1,137 @@
+function __cnf_print --argument-names message
+    echo -e 1>&2 "$message"
+end
+
+set __cnf_action
+set __cnf_force_su
+set __cnf_noprompt 0
+set __cnf_verbose 1
+
+set __cnf_actions_joined "install:info:list files:list files (paged)"
+set __cnf_actions (string split : "$__cnf_actions_joined")
+
+for opt in $argv
+    echo "$opt"
+    if test (string length "$opt") -gt 0
+        switch "$opt"
+            case noprompt
+                set __cnf_noprompt 1
+            case su
+                set __cnf_force_su
+            case quiet
+                set __cnf_verbose 0
+            case install
+                set __cnf_action "$__cnf_actions[1]"
+            case info
+                set __cnf_action "$__cnf_actions[2]"
+            case list_files
+                set __cnf_action "$__cnf_actions[3]"
+            case list_files_paged
+                set __cnf_action "$__cnf_actions[4]"
+            case '*'
+                __cnf_print "find-the-command: unknown option: $opt"
+        end
+    end
+end
+
+if test "$__cnf_verbose" -ne 0
+    function __cnf_pre_search_warn --argument-names cmd
+        __cnf_print "find-the-command: \"$cmd\" is not found locally, searching in repositories...\n"
+    end
+
+    function __cnf_cmd_not_found --argument-names cmd
+        __cnf_print "find-the-command: command not found: $cmd"
+        return 127
+    end
+else
+    function __cnf_pre_search_warn
+    end
+
+    function __cnf_cmd_not_found
+        return 127
+    end
+end
+
+if test "$__cnf_noprompt" -eq 1
+    function fish_command_not_found
+        set cmd "$argv[1]"
+        __cnf_pre_search_warn "$cmd"
+
+        set packages (pkgfile --binaries -- "$cmd" ^/dev/null)
+        switch (echo "$packages" | wc -w)
+            case 0
+                __cnf_cmd_not_found "$cmd"
+            case 1
+                __cnf_print "\"$cmd\" may be found in package \"$packages\"\n"
+            case '*'
+                __cnf_print "\"$cmd\" may be found in the following packages:\n"
+                for package in "$packages"
+                    __cnf_print "\t$package"
+                end
+        end
+    end
+else
+    set __cnf_asroot
+    if test (id -u) -ne 0
+        if set --query "$__cnf_force_su"
+            set __cnf_asroot "su -c"
+        else
+            set __cnf_asroot "sudo"
+        end
+    end
+    function fish_command_not_found
+        set cmd "$argv[1]"
+        __cnf_pre_search_warn "$cmd"
+        set packages (pkgfile --binaries -- "$cmd" ^/dev/null)
+        switch (echo "$packages" | wc -w)
+            case 0
+                __cnf_cmd_not_found "$cmd"
+            case 1
+                function __prompt_install --argument-names packages
+                    read --prompt="echo \"Would you like to install this package? (y|n) \"" result
+                    switch "$result"
+                    case 'y*'
+                    case 'Y*'
+                        "$__cnf_asroot" pacman -S "$packages"
+                    case '*'
+                        return 127
+                    end
+                end
+
+                set action
+                if test -z "$__cnf_action"
+                    __cnf_print "\"$cmd\" may be found in package \"$packages\"\n"
+                    __cnf_print "What would you like to do? "
+                    set action (echo "$__cnf_actions_joined" | tr ":" "\n" | fzf --prompt "Action (\"esc\" to abort):")
+                else
+                    set action "$__cnf_action"
+                end
+
+                switch "$action"
+                    case 'install'
+                        "$__cnf_asroot" pacman -S "$packages"
+                    case 'info'
+                        pacman -Si "$packages"
+                        __prompt_install "$packages"
+                    case 'list files'
+                        pacman -Flq "$packages"
+                        __prompt_install "$packages"
+                    case 'list files (paged)'
+                        test -z "$pager"; and set --local pager less
+                        pacman -Flq "$packages" | "$pager"
+                        __prompt_install "$packages"
+                    case '*'
+                        return 127
+                end
+            case '*'
+                __cnf_print "\"$cmd\" may be found in the following packages:\n"
+                set --local package (echo "$packages" | tr " " "\n" | fzf --prompt "Select a package to install (\"esc\" to abort):")
+                test -n "$package" and "$__cnf_asroot" pacman -S "$package" or return 127
+        end
+    end
+end
+
+function __fish_command_not_found_handler \
+    --on-event fish_command_not_found
+    fish_command_not_found "$argv"
+end


### PR DESCRIPTION
The following pull request adds support for fish. As [fish does not have a built-in `select` function](https://github.com/fish-shell/fish-shell/issues/4036), the script utilizes [fzf](https://github.com/junegunn/fzf) (this should probably be listed as an optional dependency in the PKGBUILD).