### PR TITLE
test fails in fish with fzf prompt and multiple options

### DIFF
--- a/usr/share/doc/find-the-command/ftc.fish
+++ b/usr/share/doc/find-the-command/ftc.fish
@@ -126,7 +126,7 @@ else
             case '*'
                 __cnf_print "\"$cmd\" may be found in the following packages:\n"
                 set --local package (echo "$packages" | tr " " "\n" | fzf --prompt "Select a package to install (\"esc\" to abort):")
-                test -n "$package" and "$__cnf_asroot" pacman -S "$package" or return 127
+                test -n "$package"; and "$__cnf_asroot" pacman -S "$package"; or return 127
         end
     end
 end


### PR DESCRIPTION
When using find-the-command on a binary with multiple packages (e.g. `fortune`), test will fail with the following:

```
find-the-command: "fortune" is not found locally, searching in repositories...

"fortune" may be found in the following packages:

test: Expected a combining operator like '-a' at index 3
-n community/fortune-mod and sudo pacman -S community/fortune-mod or return 127
^
/usr/share/doc/find-the-command/ftc.fish (line 129):
test -n "$package" and "$__cnf_asroot" pacman -S "$package" or return 127
^
in function 'fish_command_not_found' with arguments 'fortune'
in event handler: handler for generic event “fish_command_not_found”
```

The correct [single line] syntax seems to require semi-colons after each command